### PR TITLE
Change docker login args based on docker verison

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -59,17 +59,23 @@ function dockerVersion() {
     let args = [
       'version',
       '--format',
-      "'{{.Server.Version}}'"
+      "{{.Server.Version}}"
     ];
 
     const version = child.spawn('docker', args, {})
-    version.stdout.on('data', (data) => {
-      if (data) {
-        resolve(data.toString().slice(1, -1));
-      } else {
-        reject(new Error("Not output"));
-      }
-    });
+    var stdout_string = "";
+    version.stdout
+      .on('data', (data) => {
+        stdout_string += data.toString();
+      })
+      .on('end', () => {
+        const version = stdout_string.replace(/\r?\n/g,"");
+        if (semver.valid(version)) {
+          resolve(version);
+        } else {
+          reject(new Error("Invalid Version String: " + version));
+        }
+      });
     version.on('exit', (code, signal) => {
       if (signal || code) reject(signal || code);
     });

--- a/commands/login.js
+++ b/commands/login.js
@@ -3,6 +3,7 @@
 const cli = require('heroku-cli-util');
 const co = require('co');
 const child = require('child_process');
+const semver = require('semver');
 
 module.exports = function(topic) {
   return {
@@ -30,20 +31,47 @@ function* login(context, heroku) {
 }
 
 function dockerLogin(registry, password, verbose) {
+  return dockerVersion().then((version) => {
+    return new Promise((resolve, reject) => {
+      let args = [
+        'login',
+        '--username=_',
+        `--password=${ password }`,
+        registry
+      ];
+      if (semver.lte(version, "1.10.0")) {
+        args.splice(1, 0, '--email=_')
+      }
+      if (verbose) {
+        console.log(['> docker'].concat(args).join(' '));
+      }
+      child.spawn('docker', args, { stdio: 'inherit' })
+        .on('exit', (code, signal) => {
+          if (signal || code) reject(signal || code);
+          else resolve();
+        });
+    });
+  });
+}
+
+function dockerVersion() {
   return new Promise((resolve, reject) => {
     let args = [
-      'login',
-      '--username=_',
-      `--password=${ password }`,
-      registry
+      'version',
+      '--format',
+      "'{{.Server.Version}}'"
     ];
-    if (verbose) {
-      console.log(['> docker'].concat(args).join(' '));
-    }
-    child.spawn('docker', args, { stdio: 'inherit' })
-      .on('exit', (code, signal) => {
-        if (signal || code) reject(signal || code);
-        else resolve();
-      });
+
+    const version = child.spawn('docker', args, {})
+    version.stdout.on('data', (data) => {
+      if (data) {
+        resolve(data.toString().slice(1, -1));
+      } else {
+        reject(new Error("Not output"));
+      }
+    });
+    version.on('exit', (code, signal) => {
+      if (signal || code) reject(signal || code);
+    });
   });
 }

--- a/commands/login.js
+++ b/commands/login.js
@@ -39,7 +39,7 @@ function dockerLogin(registry, password, verbose) {
         `--password=${ password }`,
         registry
       ];
-      if (semver.lte(version, "1.10.0")) {
+      if (semver.lt(version, "1.11.0")) {
         args.splice(1, 0, '--email=_')
       }
       if (verbose) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "progress": "1.1.8",
     "request": "2.53.0",
     "superagent": "^0.21.0",
-    "yamljs": "0.2.4"
+    "yamljs": "0.2.4",
+    "semver": "5.3.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
# Fix

Change `docker login` arguments whether includes `--email` option based on docker version.
## Details
### Files Changed without Indent Diffs

 https://github.com/strobo-inc/heroku-container-registry/pull/1/files?w=
↑ is more clear to check diffs.
### Docker Version

According to [Deprecated Engine Features](https://github.com/docker/docker/blob/b826bebda0cff2cc2d3083b954c810d2889eefe5/docs/deprecated.md#-e-and---email-flags-on-docker-login), 

> ### `-e` and `--email` flags on `docker login`
> 
> **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
# Background

We use this great plugin on CircleCI. CircleCI currently supports docker 1.10.0 and below. When `--email` option is not given,  docker 1.10.0 asks an email address to user and the CircleCI step becomes timeout.
## Error Message on CircleCI

![screen shot 2016-10-07 at 09 14 54](https://cloud.githubusercontent.com/assets/661102/19175061/97e5677e-8c6e-11e6-864f-a4f95de55856.png)
## CircleCI Docker Supports
- [docker 1.10.0 is available](https://discuss.circleci.com/t/docker-1-10-0-is-available-beta/2100)
- [docker 1.11.0 requests](https://discuss.circleci.com/t/requesting-docker-1-11/3346)
- [docker 1.12.0 requests](https://discuss.circleci.com/t/request-docker-1-12/5120)
